### PR TITLE
Add offline fallback and update service worker

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Offline</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 2rem;
+      text-align: center;
+      background-color: #f7f7f9;
+    }
+  </style>
+</head>
+<body>
+  <h1>You are offline</h1>
+  <p>Sorry, the page you requested is not available. Please check your connection.</p>
+</body>
+</html>

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,8 @@ const STATIC_ASSETS = [
   '/script_top.js',
   '/manifest.json',
   '/icons/icon-192.png',
-  '/icons/icon-512.png'
+  '/icons/icon-512.png',
+  '/offline.html'
 ];
 
 self.addEventListener('install', event => {
@@ -31,13 +32,12 @@ self.addEventListener('fetch', event => {
   if (event.request.method !== 'GET') return;
   event.respondWith(
     caches.match(event.request).then(cached => {
-      const networkFetch = fetch(event.request).then(response => {
+      return fetch(event.request).then(response => {
         if (response && response.status === 200 && response.type === 'basic') {
           caches.open(CACHE_NAME).then(cache => cache.put(event.request, response.clone()));
         }
         return response;
-      }).catch(() => cached);
-      return cached || networkFetch;
-    })
+      }).catch(() => cached || caches.match('/offline.html'));
+    }).catch(() => caches.match('/offline.html'))
   );
-}); 
+});


### PR DESCRIPTION
## Summary
- create `offline.html` to show a friendly offline message
- precache the new page in the service worker
- fallback to `offline.html` when both network and cache fail

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684d1344b45483319dc6debc95fb7b33