### PR TITLE
Fix modal close button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
       width: 340px;
       max-height: 88vh;
       overflow-y: auto;
+      position: relative;
       padding: var(--space-xl) var(--space-lg) var(--space-md) var(--space-lg);
       display: flex;
       flex-direction: column;
@@ -206,14 +207,14 @@
       to { transform: translateY(0) scale(1); opacity: 1; }
     }
     .modal .close-btn {
+      position: absolute;
+      top: 1rem;
+      right: 1rem;
       background: none;
       border: none;
       font-size: 1.4rem;
       color: #3852e2;
-      align-self: flex-end;
       cursor: pointer;
-      margin-top: -0.6rem;
-      margin-bottom: -0.6rem;
     }
     .modal label {
       font-weight: 500;


### PR DESCRIPTION
## Summary
- keep the close button fixed inside the vocab modal
- adjust CSS for `.modal .close-btn`

## Testing
- `npm install puppeteer` *(fails: blocked domain)*

------
https://chatgpt.com/codex/tasks/task_e_684d232808e0833187ecc86b9404a1c8