### PR TITLE
Fix internal scrolling for settings modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,7 +605,7 @@
       }
     }
     /* Settings Modal Styles */
-    .settings-modal {
+.settings-modal {
       max-width: 400px;
       width: 95vw;
       background: #fff;
@@ -613,6 +613,8 @@
       box-shadow: 0 8px 40px #3852e266;
       padding: 2rem 1.5rem 1.5rem 1.5rem;
       position: relative;
+      max-height: 88vh;
+      overflow-y: auto;
       animation: modalIn 0.25s cubic-bezier(.36,.76,.6,1.21);
     }
     .settings-modal .close-btn {


### PR DESCRIPTION
## Summary
- ensure `.settings-modal` scrolls inside by adding `max-height` and `overflow-y`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d26f326648331aa43e4b18ec9fe02