### PR TITLE
Remove unused mobile navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,60 +403,10 @@
       color: var(--primary);
       outline: none;
     }
-    /* Hide menu button on desktop */
-    #menuBtn {
-      display: none;
-    }
-    /* Mobile nav drawer styles */
-    .mobile-nav {
-      position: fixed;
-      top: var(--header-h);
-      left: 0;
-      right: 0;
-      background: #fff;
-      box-shadow: 0 4px 16px #0002;
-      z-index: 1001;
-      padding: 1.5rem 1rem 1rem 1rem;
-      border-bottom-left-radius: 1rem;
-      border-bottom-right-radius: 1rem;
-      transform: translateY(-100%);
-      transition: transform 0.3s ease;
-    }
-    .mobile-nav.open {
-      transform: translateY(0);
-    }
-    .mobile-nav-list {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      gap: 1.2rem;
-    }
-    .mobile-nav-link {
-      color: #222;
-      text-decoration: none;
-      font-size: 1.15rem;
-      font-weight: 500;
-      padding: 0.5rem 0.2rem;
-      border-radius: 0.5rem;
-      transition: background 0.2s, color 0.2s;
-    }
-    .mobile-nav-link:hover,
-    .mobile-nav-link:focus {
-      background: #e4eafd;
-      color: var(--primary);
-      outline: none;
-    }
-    /* Responsive: hide main nav, show menu button on mobile */
+    /* Responsive: hide main nav on narrow screens */
     @media (max-width: 800px) {
       .main-nav {
         display: none;
-      }
-      #menuBtn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
       }
     }
     /* Marked.js markdown output for .ai-reply */
@@ -692,7 +642,6 @@
         </svg>
       </button>
       <button id="aiToolbarBtn" aria-label="AI Toolbar" class="toolbar-btn" aria-controls="aiToolbar" aria-expanded="false">🤖</button>
-      <button id="menuBtn" aria-label="Menu" class="menu-btn" aria-controls="mobileNav" aria-expanded="false">☰</button>
     </div>
   </header>
   <section id="aiToolbar" class="ai-toolbar" aria-label="AI Controls">
@@ -713,15 +662,6 @@
       <!-- Dynamic modal content inserted by JS -->
     </div>
   </div>
-
-  <!-- Mobile nav drawer -->
-  <nav id="mobileNav" class="mobile-nav" aria-label="Mobile navigation" aria-hidden="true">
-    <ul class="mobile-nav-list">
-      <li><a href="#" id="homeLinkMobile" class="mobile-nav-link">Home</a></li>
-      <li><a href="#" class="mobile-nav-link">About</a></li>
-      <li><a href="#" class="mobile-nav-link">Contact</a></li>
-    </ul>
-  </nav>
 
   <!-- Settings Modal -->
   <div id="settingsModalBg" class="modal-bg hidden">
@@ -1538,30 +1478,6 @@
         });
       }
 
-      // Mobile nav drawer logic
-      const menuBtn = document.getElementById('menuBtn');
-      const mobileNav = document.getElementById('mobileNav');
-      menuBtn.addEventListener('click', () => {
-          const expanded = menuBtn.getAttribute("aria-expanded") === "true";
-          menuBtn.setAttribute("aria-expanded", (!expanded).toString());
-          mobileNav.classList.toggle("open", !expanded);
-          mobileNav.setAttribute("aria-hidden", expanded ? "true" : "false");
-      });
-      // Hide mobile nav when clicking outside or on a link
-      mobileNav.addEventListener('click', (e) => {
-          if (e.target.classList.contains("mobile-nav-link")) {
-            mobileNav.classList.remove("open");
-            mobileNav.setAttribute("aria-hidden", "true");
-            menuBtn.setAttribute("aria-expanded", "false");
-          }
-        });
-        document.addEventListener("click", (e) => {
-          if (mobileNav.classList.contains("open") && !mobileNav.contains(e.target) && e.target !== menuBtn) {
-            mobileNav.classList.remove("open");
-            mobileNav.setAttribute("aria-hidden", "true");
-            menuBtn.setAttribute("aria-expanded", "false");
-          }
-        });
 
       function showHomeView() {
         currentView = 'all';
@@ -1573,18 +1489,14 @@
       }
       const savedBtn = document.getElementById('savedBtn');
       const homeLink = document.getElementById('homeLink');
-      const homeLinkMobile = document.getElementById('homeLinkMobile');
       savedBtn.addEventListener('click', e => {
         e.preventDefault();
         showSavedView();
       });
-      [homeLink, homeLinkMobile].forEach(l => l && l.addEventListener("click", e => {
+      homeLink && homeLink.addEventListener('click', e => {
         e.preventDefault();
         showHomeView();
-        mobileNav.classList.remove("open");
-        mobileNav.setAttribute("aria-hidden","true");
-        menuBtn.setAttribute("aria-expanded","false");
-      }));
+      });
 
       const onSearch = debounce(() => {
         searchQuery = searchInput.value;


### PR DESCRIPTION
## Summary
- strip out the unused mobile navigation drawer
- simplify the event handlers now that the drawer is gone

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_684ecc59c80083318ecd8b3f4ed13b63